### PR TITLE
Raw fields and working '\n' to '<br/>' conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,13 @@ active: false
 #   - volume
 #   - pages
 #   - date
+#
+# Raw fields are fields not embedded into <span></span> tags.
+# They are suitable to build links, for instance.
 
 formats:
   short: "[authors_short] [journal] [volume] [pages] [date]"
-  long: "[title]\n[authors_long] [journal] [volume] [pages] [date]"
+  long: "<a href='https://www.ncbi.nlm.nih.gov/pubmed/[uid raw]'>[title]</a>\n[authors_long] [journal] [volume] [pages] [date]"
   author_sep: ", "  # string that is inserted between list of authors when using [authors_long]
 ```
 

--- a/pubmed.php
+++ b/pubmed.php
@@ -112,7 +112,7 @@ class PubmedPlugin extends Plugin
                             $text = '<strong>' . htmlspecialchars($record['error']) . '</strong>';
                         } else {
                             $text = $format;
-                            $text = str_replace('\n', '<br>', $text);
+                            $text = str_replace("\n", '<br/>', $text);
                             foreach (['uid', 'title', 'authors_short', 'authors_long', 'journal', 'volume', 'pages', 'date'] as $field) {
                                 $replacement = '';
                                 if ($field === 'authors_short') {

--- a/pubmed.php
+++ b/pubmed.php
@@ -112,7 +112,7 @@ class PubmedPlugin extends Plugin
                             $text = '<strong>' . htmlspecialchars($record['error']) . '</strong>';
                         } else {
                             $text = $format;
-                            $text = str_replace("\n", '<br/>', $text);
+                            $text = str_replace("\n", '<br />', $text);
                             foreach (['uid', 'title', 'authors_short', 'authors_long', 'journal', 'volume', 'pages', 'date'] as $field) {
                                 $replacement = '';
                                 if ($field === 'authors_short') {
@@ -130,6 +130,10 @@ class PubmedPlugin extends Plugin
                                 $text = str_replace(
                                     '[' . $field . ']', 
                                     '<span class="' . $field . '">' . $replacement . '</span>', 
+                                    $text);
+                                $text = str_replace(
+                                    '[' . $field . ' raw]', 
+                                    strip_tags($replacement),
                                     $text);
                             }
                         }

--- a/pubmed.php
+++ b/pubmed.php
@@ -131,6 +131,10 @@ class PubmedPlugin extends Plugin
                                     '[' . $field . ']', 
                                     '<span class="' . $field . '">' . $replacement . '</span>', 
                                     $text);
+                                $text = str_replace(
+                                    '[' . $field . ' raw]', 
+                                    strip_tags($replacement),
+                                    $text);
                             }
                         }
                         $recs = $recs . '<p>' . $text . '</p>' . "\n";

--- a/pubmed.php
+++ b/pubmed.php
@@ -112,7 +112,7 @@ class PubmedPlugin extends Plugin
                             $text = '<strong>' . htmlspecialchars($record['error']) . '</strong>';
                         } else {
                             $text = $format;
-                            $text = str_replace("\n", '<br />', $text);
+                            $text = str_replace("\n", '<br/>', $text);
                             foreach (['uid', 'title', 'authors_short', 'authors_long', 'journal', 'volume', 'pages', 'date'] as $field) {
                                 $replacement = '';
                                 if ($field === 'authors_short') {
@@ -130,10 +130,6 @@ class PubmedPlugin extends Plugin
                                 $text = str_replace(
                                     '[' . $field . ']', 
                                     '<span class="' . $field . '">' . $replacement . '</span>', 
-                                    $text);
-                                $text = str_replace(
-                                    '[' . $field . ' raw]', 
-                                    strip_tags($replacement),
                                     $text);
                             }
                         }


### PR DESCRIPTION
Sometimes it is desirable to have the raw content instead of the field HTML-tagged version.

Newline conversions were not working, as they are converted to real newline characters before str_replace parses the format.